### PR TITLE
fix(cli): repair SLB operator surfaces for SkillOS close gate

### DIFF
--- a/internal/cli/approve.go
+++ b/internal/cli/approve.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	approveCmd.Flags().StringVarP(&flagApproveSessionID, "session-id", "s", "", "reviewer session ID (required)")
+	approveCmd.Flags().StringVar(&flagApproveSessionID, "session-id", "", "reviewer session ID (required)")
 	approveCmd.Flags().StringVarP(&flagApproveSessionKey, "session-key", "k", "", "session HMAC key for signing (required)")
 	approveCmd.Flags().StringVarP(&flagApproveComments, "comments", "m", "", "additional comments")
 	approveCmd.Flags().StringVar(&flagApproveTargetProject, "target-project", "", "target project path for cross-project approvals")
@@ -54,10 +54,10 @@ For cross-project reviews, use --target-project to specify which project's
 database contains the request you want to approve.
 
 	Examples:
-	  slb approve abc123 -s $SESSION_ID -k $SESSION_KEY
-	  slb approve abc123 -s $SESSION_ID -k $SESSION_KEY -m "Looks safe"
-	  slb approve abc123 -s $SESSION_ID -k $SESSION_KEY --reason-response "Valid use case"
-	  slb approve abc123 -s $SESSION_ID -k $SESSION_KEY --target-project /path/to/other/project`,
+	  slb approve abc123 --session-id $SESSION_ID -k $SESSION_KEY
+	  slb approve abc123 --session-id $SESSION_ID -k $SESSION_KEY -m "Looks safe"
+	  slb approve abc123 --session-id $SESSION_ID -k $SESSION_KEY --reason-response "Valid use case"
+	  slb approve abc123 --session-id $SESSION_ID -k $SESSION_KEY --target-project /path/to/other/project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		requestID := args[0]

--- a/internal/cli/approve_test.go
+++ b/internal/cli/approve_test.go
@@ -33,7 +33,7 @@ func newTestApproveCmd(dbPath string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  approveCmd.RunE,
 	}
-	approve.Flags().StringVarP(&flagApproveSessionID, "session-id", "s", "", "reviewer session ID (required)")
+	approve.Flags().StringVar(&flagApproveSessionID, "session-id", "", "reviewer session ID (required)")
 	approve.Flags().StringVarP(&flagApproveSessionKey, "session-key", "k", "", "session HMAC key for signing (required)")
 	approve.Flags().StringVarP(&flagApproveComments, "comments", "m", "", "additional comments")
 	approve.Flags().StringVar(&flagApproveTargetProject, "target-project", "", "target project path for cross-project approvals")
@@ -98,7 +98,7 @@ func TestApproveCommand_RequiresSessionKey(t *testing.T) {
 	resetApproveFlags()
 
 	cmd := newTestApproveCmd(h.DBPath)
-	_, _, err := executeCommand(cmd, "approve", "some-request-id", "-s", "session-123")
+	_, _, err := executeCommand(cmd, "approve", "some-request-id", "--session-id", "session-123")
 
 	if err == nil {
 		t.Fatal("expected error when --session-key is missing")
@@ -136,7 +136,7 @@ func TestApproveCommand_ApprovesRequest(t *testing.T) {
 
 	cmd := newTestApproveCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "approve", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-C", h.ProjectDir,
 		"-j",
@@ -187,7 +187,7 @@ func TestApproveCommand_WithComments(t *testing.T) {
 
 	cmd := newTestApproveCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "approve", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-m", "Looks good to me",
 		"-C", h.ProjectDir,
@@ -228,7 +228,7 @@ func TestApproveCommand_SelfReviewPrevented(t *testing.T) {
 
 	cmd := newTestApproveCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "approve", req.ID,
-		"-s", sess.ID,
+		"--session-id", sess.ID,
 		"-k", sess.SessionKey,
 		"-C", h.ProjectDir,
 		"-j",
@@ -259,7 +259,7 @@ func TestApproveCommand_InvalidSessionKey(t *testing.T) {
 
 	cmd := newTestApproveCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "approve", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", "wrong-key-not-matching",
 		"-C", h.ProjectDir,
 		"-j",
@@ -284,7 +284,7 @@ func TestApproveCommand_RequestNotFound(t *testing.T) {
 
 	cmd := newTestApproveCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "approve", "nonexistent-request",
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-C", h.ProjectDir,
 		"-j",
@@ -446,7 +446,7 @@ func TestApproveCommand_CrossProject(t *testing.T) {
 
 	cmd := newTestApproveCmd(currentH.DBPath) // Uses current project's DB by default
 	stdout, err := executeCommandCapture(t, cmd, "approve", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"--target-project", targetH.ProjectDir, // Point to target project
 		"-j",

--- a/internal/cli/emergency.go
+++ b/internal/cli/emergency.go
@@ -32,7 +32,7 @@ func init() {
 	emergencyCmd.Flags().BoolVarP(&flagEmergencyYes, "yes", "y", false, "skip interactive confirmation")
 	emergencyCmd.Flags().StringVar(&flagEmergencyAck, "ack", "", "command hash acknowledgment (required with --yes)")
 	emergencyCmd.Flags().BoolVar(&flagEmergencyCapture, "capture-rollback", false, "capture state for rollback")
-	emergencyCmd.Flags().IntVarP(&flagEmergencyTimeout, "timeout", "t", 300, "execution timeout in seconds")
+	emergencyCmd.Flags().IntVar(&flagEmergencyTimeout, "timeout", 300, "execution timeout in seconds")
 	emergencyCmd.Flags().StringVar(&flagEmergencyLogDir, "log-dir", ".slb/logs", "directory for execution logs")
 
 	rootCmd.AddCommand(emergencyCmd)

--- a/internal/cli/emergency_test.go
+++ b/internal/cli/emergency_test.go
@@ -35,7 +35,7 @@ func newTestEmergencyCmd(dbPath string) *cobra.Command {
 	emCmd.Flags().BoolVarP(&flagEmergencyYes, "yes", "y", false, "skip interactive confirmation")
 	emCmd.Flags().StringVar(&flagEmergencyAck, "ack", "", "command hash acknowledgment")
 	emCmd.Flags().BoolVar(&flagEmergencyCapture, "capture-rollback", false, "capture state for rollback")
-	emCmd.Flags().IntVarP(&flagEmergencyTimeout, "timeout", "t", 300, "execution timeout")
+	emCmd.Flags().IntVar(&flagEmergencyTimeout, "timeout", 300, "execution timeout")
 	emCmd.Flags().StringVar(&flagEmergencyLogDir, "log-dir", ".slb/logs", "log directory")
 
 	root.AddCommand(emCmd)

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -21,8 +21,8 @@ var (
 )
 
 func init() {
-	executeCmd.Flags().StringVarP(&flagExecuteSessionID, "session-id", "s", "", "executor session ID (required)")
-	executeCmd.Flags().IntVarP(&flagExecuteTimeout, "timeout", "t", 300, "execution timeout in seconds")
+	executeCmd.Flags().StringVar(&flagExecuteSessionID, "session-id", "", "executor session ID (required)")
+	executeCmd.Flags().IntVar(&flagExecuteTimeout, "timeout", 300, "execution timeout in seconds")
 	executeCmd.Flags().BoolVar(&flagExecuteBackground, "background", false, "run in background, return immediately")
 	executeCmd.Flags().StringVar(&flagExecuteLogDir, "log-dir", ".slb/logs", "directory for execution logs")
 	// Reuse Agent Mail notifier builder from approve/reject
@@ -46,9 +46,9 @@ Gate conditions are validated before execution:
 - Current pattern policy must not require higher tier
 
 Examples:
-  slb execute abc123 -s $SESSION_ID
-  slb execute abc123 -s $SESSION_ID --timeout 600
-  slb execute abc123 -s $SESSION_ID --background`,
+  slb execute abc123 --session-id $SESSION_ID
+  slb execute abc123 --session-id $SESSION_ID --timeout 600
+  slb execute abc123 --session-id $SESSION_ID --background`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		requestID := args[0]

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -78,6 +78,10 @@ Examples:
 			return fmt.Errorf("loading config: %w", err)
 		}
 
+		if _, err := loadCustomPatternsIntoDefaultEngine(); err != nil {
+			return fmt.Errorf("loading custom patterns: %w", err)
+		}
+
 		// Create executor
 		executor := core.NewExecutor(dbConn, nil).WithNotifier(buildAgentMailNotifier(req.ProjectPath))
 

--- a/internal/cli/execute_test.go
+++ b/internal/cli/execute_test.go
@@ -31,8 +31,8 @@ func newTestExecuteCmd(dbPath string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  executeCmd.RunE,
 	}
-	execCmd.Flags().StringVarP(&flagExecuteSessionID, "session-id", "s", "", "executor session ID")
-	execCmd.Flags().IntVarP(&flagExecuteTimeout, "timeout", "t", 300, "timeout seconds")
+	execCmd.Flags().StringVar(&flagExecuteSessionID, "session-id", "", "executor session ID")
+	execCmd.Flags().IntVar(&flagExecuteTimeout, "timeout", 300, "timeout seconds")
 	execCmd.Flags().BoolVar(&flagExecuteBackground, "background", false, "run in background")
 	execCmd.Flags().StringVar(&flagExecuteLogDir, "log-dir", ".slb/logs", "log directory")
 
@@ -94,7 +94,7 @@ func TestExecuteCommand_RequestNotFound(t *testing.T) {
 
 	cmd := newTestExecuteCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "execute", "nonexistent-request-id",
-		"-s", sess.ID,
+		"--session-id", sess.ID,
 		"-j",
 	)
 
@@ -118,7 +118,7 @@ func TestExecuteCommand_CannotExecutePending(t *testing.T) {
 
 	cmd := newTestExecuteCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "execute", req.ID,
-		"-s", sess.ID,
+		"--session-id", sess.ID,
 		"-j",
 	)
 
@@ -150,7 +150,7 @@ func TestExecuteCommand_ExecutesApprovedRequest(t *testing.T) {
 
 	cmd := newTestExecuteCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "execute", req.ID,
-		"-s", sess.ID,
+		"--session-id", sess.ID,
 		"-j",
 	)
 
@@ -231,8 +231,8 @@ func TestExecuteCommand_CustomTimeout(t *testing.T) {
 
 	cmd := newTestExecuteCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "execute", req.ID,
-		"-s", sess.ID,
-		"-t", "10", // Short timeout
+		"--session-id", sess.ID,
+		"--timeout", "10",
 		"-j",
 	)
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -102,11 +102,11 @@ func showQuickReference() {
 	requestor := renderSection(useUnicode, "🔶 AS REQUESTOR (dangerous commands)", []string{
 		bullet("slb run \"rm -rf ./build\" -s $SID --reason \"Cleanup\" --timeout 300 -j", "classify, request approval, wait, then execute"),
 		bullet("slb status <request-id> --wait -j", "block until approved/rejected/timeout"),
-		bullet("slb execute <request-id> -s $SID -j", "execute once approved (client-side)"),
+		bullet("slb execute <request-id> --session-id $SID -j", "execute once approved (client-side)"),
 	})
 
 	plumbing := renderSection(useUnicode, "🔧 PLUMBING (advanced)", []string{
-		bullet("slb request \"...\" --wait --execute -s $SID --reason \"...\"", "submit without shorthand"),
+		bullet("slb request \"...\" --wait --execute --session-id $SID --reason \"...\"", "submit without shorthand"),
 		bullet("slb cancel <request-id>", "cancel pending"),
 		bullet("slb rollback <request-id>", "apply rollback capture (if available)"),
 	})
@@ -114,8 +114,8 @@ func showQuickReference() {
 	reviewer := renderSection(useUnicode, "🔷 AS REVIEWER (check frequently)", []string{
 		bullet("slb pending -j", "list pending approvals"),
 		bullet("slb review <id> -j", "inspect details"),
-		bullet("slb approve <id> -s $SID -k $SKEY --reason-response \"Verified\"", "approve (signed)"),
-		bullet("slb reject <id> -s $SID -k $SKEY --reason \"Need safer path\"", "reject (signed)"),
+		bullet("slb approve <id> --session-id $SID -k $SKEY --reason-response \"Verified\"", "approve (signed)"),
+		bullet("slb reject <id> --session-id $SID -k $SKEY --reason \"Need safer path\"", "reject (signed)"),
 	})
 
 	patterns := renderSection(useUnicode, "🛡️ PATTERNS (agents can add, not remove)", []string{

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -26,7 +26,7 @@ func init() {
 	hookInstallCmd.Flags().BoolVarP(&flagHookForce, "force", "f", false, "overwrite existing hooks")
 
 	// hook generate flags
-	hookGenerateCmd.Flags().StringVarP(&flagHookOutputDir, "output", "o", "", "output directory (default: ~/.slb/hooks/)")
+	hookGenerateCmd.Flags().StringVar(&flagHookOutputDir, "output", "", "output directory (default: ~/.slb/hooks/)")
 
 	// Add subcommands
 	hookCmd.AddCommand(hookGenerateCmd)

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -35,7 +35,7 @@ func newTestHookCmd(dbPath string) *cobra.Command {
 		Short: "Generate the Python hook script",
 		RunE:  hookGenerateCmd.RunE,
 	}
-	generateCmd.Flags().StringVarP(&flagHookOutputDir, "output", "o", "", "output directory")
+	generateCmd.Flags().StringVar(&flagHookOutputDir, "output", "", "output directory")
 
 	installCmd := &cobra.Command{
 		Use:   "install",
@@ -115,7 +115,7 @@ func TestHookGenerateCommand_GeneratesScript(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	cmd := newTestHookCmd(h.DBPath)
-	stdout, err := executeCommandCapture(t, cmd, "hook", "generate", "-o", tmpDir, "-j")
+	stdout, err := executeCommandCapture(t, cmd, "hook", "generate", "--output", tmpDir, "-j")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -171,7 +171,7 @@ func TestHookGenerateCommand_ScriptIsExecutable(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	cmd := newTestHookCmd(h.DBPath)
-	_, err := executeCommandCapture(t, cmd, "hook", "generate", "-o", tmpDir, "-j")
+	_, err := executeCommandCapture(t, cmd, "hook", "generate", "--output", tmpDir, "-j")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -684,7 +684,7 @@ func TestGenerateHookScript_ContainsEssentialComponents(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	cmd := newTestHookCmd(h.DBPath)
-	_, err := executeCommandCapture(t, cmd, "hook", "generate", "-o", tmpDir, "-j")
+	_, err := executeCommandCapture(t, cmd, "hook", "generate", "--output", tmpDir, "-j")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -734,7 +734,7 @@ func TestHookGenerateCommand_GeneratedScriptShapeIsCorrect(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	cmd := newTestHookCmd(h.DBPath)
-	if _, err := executeCommandCapture(t, cmd, "hook", "generate", "-o", tmpDir, "-j"); err != nil {
+	if _, err := executeCommandCapture(t, cmd, "hook", "generate", "--output", tmpDir, "-j"); err != nil {
 		t.Fatalf("hook generate: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(tmpDir, "slb_guard.py"))
@@ -801,7 +801,7 @@ func TestHookGenerateCommand_SocketPathWalksUpToProjectRoot(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	cmd := newTestHookCmd(h.DBPath)
-	if _, err := executeCommandCapture(t, cmd, "hook", "generate", "-o", tmpDir, "-j"); err != nil {
+	if _, err := executeCommandCapture(t, cmd, "hook", "generate", "--output", tmpDir, "-j"); err != nil {
 		t.Fatalf("hook generate: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(tmpDir, "slb_guard.py"))
@@ -844,7 +844,7 @@ func TestHookGenerateCommand_IncludesPersistedCustomPatterns(t *testing.T) {
 	tmpDir := t.TempDir()
 	hookCmd := newTestHookCmd(h.DBPath)
 	if _, err := executeCommandCapture(t, hookCmd, "hook", "generate",
-		"-o", tmpDir, "-j",
+		"--output", tmpDir, "-j",
 	); err != nil {
 		t.Fatalf("hook generate: %v", err)
 	}

--- a/internal/cli/patterns.go
+++ b/internal/cli/patterns.go
@@ -108,7 +108,7 @@ func init() {
 
 	// patterns export flags
 	patternsExportCmd.Flags().StringVarP(&flagPatternFormat, "format", "f", "json", "export format: json, yaml, claude-hook")
-	patternsExportCmd.Flags().StringVarP(&flagPatternOutputFile, "output", "o", "", "output file (default: stdout)")
+	patternsExportCmd.Flags().StringVar(&flagPatternOutputFile, "output", "", "output file (default: stdout)")
 
 	// Add subcommands
 	patternsCmd.AddCommand(patternsListCmd)
@@ -456,8 +456,8 @@ Available formats:
 Examples:
   slb patterns export                         # JSON to stdout
   slb patterns export --format=claude-hook    # Python to stdout
-  slb patterns export -o patterns.json        # JSON to file
-  slb patterns export -f claude-hook -o hook.py  # Python to file`,
+  slb patterns export --output patterns.json        # JSON to file
+  slb patterns export -f claude-hook --output hook.py  # Python to file`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := loadCustomPatternsIntoDefaultEngine(); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: %v\n", err)

--- a/internal/cli/patterns_test.go
+++ b/internal/cli/patterns_test.go
@@ -88,7 +88,7 @@ func newTestPatternsCmd(dbPath string) *cobra.Command {
 		RunE:  patternsExportCmd.RunE,
 	}
 	exportCmd.Flags().StringVarP(&flagPatternFormat, "format", "f", "json", "export format")
-	exportCmd.Flags().StringVarP(&flagPatternOutputFile, "output", "o", "", "output file")
+	exportCmd.Flags().StringVar(&flagPatternOutputFile, "output", "", "output file")
 
 	// Version command
 	versionCmd := &cobra.Command{

--- a/internal/cli/patterns_test.go
+++ b/internal/cli/patterns_test.go
@@ -233,16 +233,20 @@ func TestPatternsTestCommand_SafeCommand(t *testing.T) {
 		t.Fatalf("failed to parse JSON: %v\nstdout: %s", err, stdout)
 	}
 
-	// Echo may or may not be safe depending on pattern configuration
-	// Just verify the output structure has the expected fields
 	if result["command"] != "echo hello" {
 		t.Errorf("expected command='echo hello', got %v", result["command"])
 	}
-	if _, ok := result["needs_approval"]; !ok {
-		t.Error("expected needs_approval field in result")
+	if result["needs_approval"] != false {
+		t.Errorf("expected needs_approval=false, got %v", result["needs_approval"])
 	}
-	if _, ok := result["is_safe"]; !ok {
-		t.Error("expected is_safe field in result")
+	if result["is_safe"] != true {
+		t.Errorf("expected is_safe=true, got %v", result["is_safe"])
+	}
+	if result["tier"] != "safe" {
+		t.Errorf("expected tier=safe, got %v", result["tier"])
+	}
+	if result["matched_pattern"] != "unmatched_default_allow" {
+		t.Errorf("expected matched_pattern=unmatched_default_allow, got %v", result["matched_pattern"])
 	}
 }
 
@@ -264,6 +268,12 @@ func TestCheckCommand_AliasForTest(t *testing.T) {
 
 	if result["command"] != "echo hello" {
 		t.Errorf("expected command='echo hello', got %v", result["command"])
+	}
+	if result["tier"] != "safe" {
+		t.Errorf("expected tier=safe, got %v", result["tier"])
+	}
+	if result["is_safe"] != true {
+		t.Errorf("expected is_safe=true, got %v", result["is_safe"])
 	}
 }
 

--- a/internal/cli/reject.go
+++ b/internal/cli/reject.go
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-	rejectCmd.Flags().StringVarP(&flagRejectSessionID, "session-id", "s", "", "reviewer session ID (required)")
+	rejectCmd.Flags().StringVar(&flagRejectSessionID, "session-id", "", "reviewer session ID (required)")
 	rejectCmd.Flags().StringVarP(&flagRejectSessionKey, "session-key", "k", "", "session HMAC key for signing (required)")
 	rejectCmd.Flags().StringVarP(&flagRejectReason, "reason", "r", "", "reason for rejection (required)")
 	rejectCmd.Flags().StringVarP(&flagRejectComments, "comments", "m", "", "additional comments")
@@ -44,9 +44,9 @@ For cross-project reviews, use --target-project to specify which project's
 database contains the request you want to reject.
 
 	Examples:
-	  slb reject abc123 -s $SESSION_ID -k $SESSION_KEY -r "Command too dangerous"
-	  slb reject abc123 -s $SESSION_ID -k $SESSION_KEY -r "Justification insufficient" -m "Please add more context"
-	  slb reject abc123 -s $SESSION_ID -k $SESSION_KEY -r "Too risky" --target-project /path/to/other/project`,
+	  slb reject abc123 --session-id $SESSION_ID -k $SESSION_KEY -r "Command too dangerous"
+	  slb reject abc123 --session-id $SESSION_ID -k $SESSION_KEY -r "Justification insufficient" -m "Please add more context"
+	  slb reject abc123 --session-id $SESSION_ID -k $SESSION_KEY -r "Too risky" --target-project /path/to/other/project`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		requestID := args[0]

--- a/internal/cli/reject_test.go
+++ b/internal/cli/reject_test.go
@@ -31,7 +31,7 @@ func newTestRejectCmd(dbPath string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  rejectCmd.RunE,
 	}
-	reject.Flags().StringVarP(&flagRejectSessionID, "session-id", "s", "", "reviewer session ID (required)")
+	reject.Flags().StringVar(&flagRejectSessionID, "session-id", "", "reviewer session ID (required)")
 	reject.Flags().StringVarP(&flagRejectSessionKey, "session-key", "k", "", "session HMAC key for signing (required)")
 	reject.Flags().StringVarP(&flagRejectReason, "reason", "r", "", "reason for rejection (required)")
 	reject.Flags().StringVarP(&flagRejectComments, "comments", "m", "", "additional comments")
@@ -90,7 +90,7 @@ func TestRejectCommand_RequiresSessionKey(t *testing.T) {
 	resetRejectFlags()
 
 	cmd := newTestRejectCmd(h.DBPath)
-	_, _, err := executeCommand(cmd, "reject", "some-request-id", "-s", "session-123")
+	_, _, err := executeCommand(cmd, "reject", "some-request-id", "--session-id", "session-123")
 
 	if err == nil {
 		t.Fatal("expected error when --session-key is missing")
@@ -106,7 +106,7 @@ func TestRejectCommand_RequiresReason(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	_, _, err := executeCommand(cmd, "reject", "some-request-id",
-		"-s", "session-123",
+		"--session-id", "session-123",
 		"-k", "some-key",
 	)
 
@@ -146,7 +146,7 @@ func TestRejectCommand_RejectsRequest(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "reject", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-r", "Command too dangerous",
 		"-C", h.ProjectDir,
@@ -201,7 +201,7 @@ func TestRejectCommand_WithComments(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	stdout, err := executeCommandCapture(t, cmd, "reject", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-r", "Insufficient justification",
 		"-m", "Please add more context about why this is needed",
@@ -245,7 +245,7 @@ func TestRejectCommand_SelfReviewPrevented(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "reject", req.ID,
-		"-s", sess.ID,
+		"--session-id", sess.ID,
 		"-k", sess.SessionKey,
 		"-r", "Trying to reject own request",
 		"-C", h.ProjectDir,
@@ -277,7 +277,7 @@ func TestRejectCommand_InvalidSessionKey(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "reject", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", "wrong-key-not-matching",
 		"-r", "Some reason",
 		"-C", h.ProjectDir,
@@ -303,7 +303,7 @@ func TestRejectCommand_RequestNotFound(t *testing.T) {
 
 	cmd := newTestRejectCmd(h.DBPath)
 	_, err := executeCommandCapture(t, cmd, "reject", "nonexistent-request",
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-r", "Some reason",
 		"-C", h.ProjectDir,
@@ -371,7 +371,7 @@ func TestRejectCommand_CrossProject(t *testing.T) {
 
 	cmd := newTestRejectCmd(currentH.DBPath) // Uses current project's DB by default
 	stdout, err := executeCommandCapture(t, cmd, "reject", req.ID,
-		"-s", reviewerSess.ID,
+		"--session-id", reviewerSess.ID,
 		"-k", reviewerSess.SessionKey,
 		"-r", "Command too risky for cross-project operation",
 		"--target-project", targetH.ProjectDir, // Point to target project

--- a/internal/cli/request.go
+++ b/internal/cli/request.go
@@ -127,6 +127,32 @@ Use --execute with --wait to execute after approval.`,
 
 		// If skipped (safe command), return immediately
 		if result.Skipped {
+			if flagRequestExecute {
+				resp := map[string]any{
+					"status":         "refused",
+					"failure_class":  "skipped_command_not_reviewable",
+					"reason":         result.SkipReason,
+					"command":        command,
+					"actual_actions": []any{},
+					"remediation":    "Use slb run for no-approval execution, or add a matching pattern before requesting approval for protected-surface mutations.",
+				}
+				if result.Classification != nil {
+					resp["needs_approval"] = result.Classification.NeedsApproval
+					resp["is_safe"] = result.Classification.IsSafe
+					resp["min_approvals"] = result.Classification.MinApprovals
+					if result.Classification.Tier != "" {
+						resp["tier"] = string(result.Classification.Tier)
+					} else {
+						resp["tier"] = nil
+					}
+				}
+				if err := out.Write(resp); err != nil {
+					return err
+				}
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
+				return fmt.Errorf("cannot execute skipped command: %s", result.SkipReason)
+			}
 			return out.Write(map[string]any{
 				"status":  "skipped",
 				"reason":  result.SkipReason,

--- a/internal/cli/request.go
+++ b/internal/cli/request.go
@@ -63,9 +63,10 @@ Use --execute with --wait to execute after approval.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		command := args[0]
+		out := output.New(output.Format(GetOutput()))
 
 		if flagSessionID == "" {
-			return fmt.Errorf("--session-id is required to create a request")
+			return writeError(cmd, out, "missing_session_id", command, fmt.Errorf("--session-id is required to create a request"))
 		}
 
 		project, err := projectPath()
@@ -122,8 +123,6 @@ Use --execute with --wait to execute after approval.`,
 		if err != nil {
 			return fmt.Errorf("creating request: %w", err)
 		}
-
-		out := output.New(output.Format(GetOutput()))
 
 		// If skipped (safe command), return immediately
 		if result.Skipped {

--- a/internal/cli/request.go
+++ b/internal/cli/request.go
@@ -103,6 +103,10 @@ Use --execute with --wait to execute after approval.`,
 			return fmt.Errorf("collecting attachments: %w", err)
 		}
 
+		if _, err := loadCustomPatternsIntoDefaultEngine(); err != nil {
+			return fmt.Errorf("loading custom patterns: %w", err)
+		}
+
 		// Create the request using the core logic (config-driven rate limits + integrations).
 		rl := core.NewRateLimiter(dbConn, toRateLimitConfig(cfg))
 		creator := core.NewRequestCreator(dbConn, rl, nil, toRequestCreatorConfig(cfg))

--- a/internal/cli/request_test.go
+++ b/internal/cli/request_test.go
@@ -232,6 +232,46 @@ func TestRequestCommand_SafeCommandSkipped(t *testing.T) {
 	}
 }
 
+func TestRequestCommand_ExecuteSkippedCommandRefusesTyped(t *testing.T) {
+	h := testutil.NewHarness(t)
+	resetRequestFlags()
+
+	sess := testutil.MakeSession(t, h.DB,
+		testutil.WithProject(h.ProjectDir),
+		testutil.WithAgent("TestAgent"),
+	)
+
+	cmd := newTestRequestCmd(h.DBPath)
+	stdout, err := executeCommandCapture(t, cmd, "request", "ls",
+		"-s", sess.ID,
+		"-C", h.ProjectDir,
+		"--execute",
+		"-j",
+	)
+
+	if err == nil {
+		t.Fatal("expected typed refusal when --execute is used on a skipped command")
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nstdout: %s", err, stdout)
+	}
+
+	if result["status"] != "refused" {
+		t.Errorf("expected status=refused, got %v", result["status"])
+	}
+	if result["failure_class"] != "skipped_command_not_reviewable" {
+		t.Errorf("expected skipped_command_not_reviewable failure_class, got %v", result["failure_class"])
+	}
+	if actions, ok := result["actual_actions"].([]any); !ok || len(actions) != 0 {
+		t.Errorf("expected actual_actions=[], got %#v", result["actual_actions"])
+	}
+	if result["remediation"] == "" {
+		t.Error("expected remediation to be set")
+	}
+}
+
 func TestRequestCommand_InvalidSession(t *testing.T) {
 	h := testutil.NewHarness(t)
 	resetRequestFlags()

--- a/internal/cli/request_test.go
+++ b/internal/cli/request_test.go
@@ -89,13 +89,27 @@ func TestRequestCommand_RequiresSessionID(t *testing.T) {
 	resetRequestFlags()
 
 	cmd := newTestRequestCmd(h.DBPath)
-	_, _, err := executeCommand(cmd, "request", "ls -la", "-C", h.ProjectDir)
+	stdout, err := executeCommandCapture(t, cmd, "request", "ls -la", "-C", h.ProjectDir, "-j")
 
 	if err == nil {
 		t.Fatal("expected error when --session-id is missing")
 	}
 	if !strings.Contains(err.Error(), "--session-id is required") {
 		t.Errorf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result["status"] != "missing_session_id" {
+		t.Errorf("expected status=missing_session_id, got %v", result["status"])
+	}
+	if result["command"] != "ls -la" {
+		t.Errorf("expected command ls -la, got %v", result["command"])
+	}
+	if !strings.Contains(result["error"].(string), "--session-id is required") {
+		t.Errorf("unexpected error payload: %v", result["error"])
 	}
 }
 

--- a/internal/cli/request_test.go
+++ b/internal/cli/request_test.go
@@ -281,14 +281,9 @@ func TestRequestCommand_SafeCommandSkipped(t *testing.T) {
 		t.Logf("Full result: %+v", result)
 		t.Errorf("expected status=skipped for safe command, got %v", result["status"])
 	}
-	// Tier should be "safe" (not a db constant since safe commands are skipped)
-	tier := result["tier"]
-	if tier == nil || tier == "" {
+	if result["tier"] != "safe" {
 		t.Logf("Full result: %+v", result)
-		// Some commands might not have tier in skipped response
-		// so we just verify the status is skipped
-	} else if tier != "safe" {
-		t.Errorf("expected tier=safe, got %v", tier)
+		t.Errorf("expected tier=safe, got %v", result["tier"])
 	}
 }
 

--- a/internal/cli/request_test.go
+++ b/internal/cli/request_test.go
@@ -156,6 +156,52 @@ func TestRequestCommand_CreatesDangerousRequest(t *testing.T) {
 	}
 }
 
+func TestRequestCommand_LoadsCustomPatternForProtectedHomeInstall(t *testing.T) {
+	h := testutil.NewHarness(t)
+	resetRequestFlags()
+
+	session := testutil.MakeSession(t, h.DB,
+		testutil.WithProject(h.ProjectDir),
+		testutil.WithAgent("GrayTower"),
+	)
+	if _, err := h.DB.InsertCustomPattern(
+		"dangerous",
+		`^install\s+.*\s+/Users/josh/\.local/bin/[^[:space:]]+$`,
+		"protected HOME wrapper installs require approval",
+		"test",
+	); err != nil {
+		t.Fatalf("InsertCustomPattern: %v", err)
+	}
+
+	protectedInstall := "install -m 0755 /Users/josh/Developer/skillos/scripts/skillos_br_close_audit_gate.py /Users/josh/.local/bin/skillos-br-close-audit-gate"
+	cmd := newTestRequestCmd(h.DBPath)
+	stdout, err := executeCommandCapture(t, cmd,
+		"request",
+		protectedInstall,
+		"-C", h.ProjectDir,
+		"--session-id", session.ID,
+		"--reason", "regression",
+		"-j",
+	)
+	if err != nil {
+		t.Fatalf("request returned error: %v\nstdout: %s", err, stdout)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse request JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result["status"] != "pending" {
+		t.Fatalf("expected pending request, got %v\nstdout: %s", result["status"], stdout)
+	}
+	if result["tier"] != "dangerous" {
+		t.Fatalf("expected tier=dangerous, got %v\nstdout: %s", result["tier"], stdout)
+	}
+	if result["min_approvals"] != float64(1) {
+		t.Fatalf("expected min_approvals=1, got %v\nstdout: %s", result["min_approvals"], stdout)
+	}
+}
+
 func TestRequestCommand_WithJustification(t *testing.T) {
 	h := testutil.NewHarness(t)
 	resetRequestFlags()

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Dicklesworthstone/slb/internal/testutil"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // executeCommand runs a cobra command with the given args and returns stdout, stderr, and error.
@@ -123,6 +124,37 @@ func TestRootCommand_GlobalFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProductionCommandTree_LocalShorthandsDoNotCollideWithPersistentFlags(t *testing.T) {
+	var walk func(cmd *cobra.Command, inherited map[string]string)
+	walk = func(cmd *cobra.Command, inherited map[string]string) {
+		cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+			if flag.Shorthand == "" {
+				return
+			}
+			if owner, ok := inherited[flag.Shorthand]; ok {
+				t.Errorf("%s local flag --%s reuses -%s from persistent flag %s",
+					cmd.CommandPath(), flag.Name, flag.Shorthand, owner)
+			}
+		})
+
+		next := make(map[string]string, len(inherited))
+		for shorthand, owner := range inherited {
+			next[shorthand] = owner
+		}
+		cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			if flag.Shorthand != "" {
+				next[flag.Shorthand] = cmd.CommandPath() + " --" + flag.Name
+			}
+		})
+
+		for _, child := range cmd.Commands() {
+			walk(child, next)
+		}
+	}
+
+	walk(rootCmd, map[string]string{})
 }
 
 func TestVersionCommand_TextOutput(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -105,6 +105,10 @@ Examples:
 			return writeError(cmd, out, "attachment_error", command, err)
 		}
 
+		if _, err := loadCustomPatternsIntoDefaultEngine(); err != nil {
+			return writeError(cmd, out, "policy_load_failed", command, err)
+		}
+
 		// Step 1: Classify and create request using config-derived limits and notifiers
 		rl := core.NewRateLimiter(dbConn, toRateLimitConfig(cfg))
 		creator := core.NewRequestCreator(dbConn, rl, nil, toRequestCreatorConfig(cfg))
@@ -254,6 +258,10 @@ func runSafeCommand(cmd *cobra.Command, out *output.Writer, command, cwd, projec
 }
 
 func runApprovedRequest(ctx context.Context, out *output.Writer, dbConn *db.DB, cfg config.Config, project, requestID string) (int, error) {
+	if _, err := loadCustomPatternsIntoDefaultEngine(); err != nil {
+		return 1, fmt.Errorf("loading custom patterns: %w", err)
+	}
+
 	executor := core.NewExecutor(dbConn, nil).WithNotifier(buildAgentMailNotifier(project))
 
 	execResult, execErr := executor.ExecuteApprovedRequest(ctx, core.ExecuteOptions{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -65,9 +65,10 @@ Examples:
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		command := args[0]
+		out := output.New(output.Format(GetOutput()))
 
 		if flagSessionID == "" {
-			return fmt.Errorf("--session-id is required")
+			return writeError(cmd, out, "missing_session_id", command, fmt.Errorf("--session-id is required"))
 		}
 
 		project, err := projectPath()
@@ -93,8 +94,6 @@ Examples:
 			return fmt.Errorf("opening database: %w", err)
 		}
 		defer dbConn.Close()
-
-		out := output.New(output.Format(GetOutput()))
 
 		// Collect attachments from flags
 		attachments, err := CollectAttachments(cmd.Context(), AttachmentFlags{

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,13 +88,27 @@ func TestRunCommand_RequiresSessionID(t *testing.T) {
 	resetRunFlags()
 
 	cmd := newTestRunCmd(h.DBPath)
-	_, _, err := executeCommand(cmd, "run", "echo hello", "-C", h.ProjectDir)
+	stdout, err := executeCommandCapture(t, cmd, "run", "echo hello", "-C", h.ProjectDir, "-j")
 
 	if err == nil {
 		t.Fatal("expected error when --session-id is missing")
 	}
 	if !strings.Contains(err.Error(), "--session-id is required") {
 		t.Errorf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result["status"] != "missing_session_id" {
+		t.Errorf("expected status=missing_session_id, got %v", result["status"])
+	}
+	if result["command"] != "echo hello" {
+		t.Errorf("expected command echo hello, got %v", result["command"])
+	}
+	if !strings.Contains(result["error"].(string), "--session-id is required") {
+		t.Errorf("unexpected error payload: %v", result["error"])
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -140,6 +140,52 @@ func TestRunCommand_Help(t *testing.T) {
 	}
 }
 
+func TestRunCommand_YieldLoadsCustomPatternsBeforeSafeExecution(t *testing.T) {
+	h := testutil.NewHarness(t)
+	resetRunFlags()
+
+	session := testutil.MakeSession(t, h.DB,
+		testutil.WithProject(h.ProjectDir),
+		testutil.WithAgent("GrayTower"),
+	)
+	if _, err := h.DB.InsertCustomPattern(
+		"dangerous",
+		`^echo\s+SLB_RUN_CUSTOM_PATTERN_SENTINEL$`,
+		"run must honor persisted custom patterns before safe execution",
+		"test",
+	); err != nil {
+		t.Fatalf("InsertCustomPattern: %v", err)
+	}
+
+	cmd := newTestRunCmd(h.DBPath)
+	stdout, err := executeCommandCapture(t, cmd,
+		"run",
+		"echo SLB_RUN_CUSTOM_PATTERN_SENTINEL",
+		"-C", h.ProjectDir,
+		"--session-id", session.ID,
+		"--reason", "regression",
+		"--yield",
+		"-j",
+	)
+	if err != nil {
+		t.Fatalf("run --yield returned error: %v\nstdout: %s", err, stdout)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse run JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result["status"] != "pending" {
+		t.Fatalf("expected pending request, got %v\nstdout: %s", result["status"], stdout)
+	}
+	if result["tier"] != "dangerous" {
+		t.Fatalf("expected tier=dangerous, got %v\nstdout: %s", result["tier"], stdout)
+	}
+	if result["min_approvals"] != float64(1) {
+		t.Fatalf("expected min_approvals=1, got %v\nstdout: %s", result["min_approvals"], stdout)
+	}
+}
+
 // Note: TestRunCommand_InvalidSession is skipped because the run command
 // calls os.Exit on errors, which would terminate the test process.
 // This behavior would need to be refactored to support proper testing.

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -23,7 +23,7 @@ var (
 )
 
 func init() {
-	watchCmd.Flags().StringVarP(&flagWatchSessionID, "session-id", "s", "", "session ID for auto-approve attribution")
+	watchCmd.Flags().StringVar(&flagWatchSessionID, "session-id", "", "session ID for auto-approve attribution")
 	watchCmd.Flags().BoolVar(&flagWatchAutoApproveCaution, "auto-approve-caution", false, "automatically approve CAUTION tier requests")
 	watchCmd.Flags().DurationVar(&flagWatchPollInterval, "poll-interval", 2*time.Second, "polling interval when daemon not available")
 

--- a/internal/core/patterns.go
+++ b/internal/core/patterns.go
@@ -52,6 +52,8 @@ type SegmentMatch struct {
 	MatchedPattern string
 }
 
+const defaultAllowPattern = "unmatched_default_allow"
+
 // PatternEngine handles pattern matching for risk classification.
 type PatternEngine struct {
 	mu sync.RWMutex
@@ -189,7 +191,11 @@ func (e *PatternEngine) ClassifyCommand(cmd, cwd string) *MatchResult {
 
 	// For compound commands, check each segment
 	if normalized.IsCompound && len(normalized.Segments) > 1 {
-		return e.applyParseUpgrade(e.classifyCompoundCommand(normalized, cwd), normalized.ParseError)
+		compound := e.classifyCompoundCommand(normalized, cwd)
+		if !normalized.ParseError && compound.Tier == "" {
+			markDefaultAllow(compound)
+		}
+		return e.applyParseUpgrade(compound, normalized.ParseError)
 	}
 
 	// Get the command to check - use normalized primary if available
@@ -260,7 +266,11 @@ func (e *PatternEngine) ClassifyCommand(cmd, cwd string) *MatchResult {
 		return e.applyParseUpgrade(result, normalized.ParseError)
 	}
 
-	// No match → allowed without review
+	// No match → allowed without review. Surface it as an explicit SAFE
+	// classification so robot consumers never have to interpret a null tier.
+	if !normalized.ParseError {
+		markDefaultAllow(result)
+	}
 	return e.applyParseUpgrade(result, normalized.ParseError)
 }
 
@@ -380,6 +390,16 @@ func (e *PatternEngine) matchPatterns(cmd string, patterns []*Pattern) *Pattern 
 		}
 	}
 	return nil
+}
+
+func markDefaultAllow(res *MatchResult) {
+	res.Tier = RiskTier(RiskSafe)
+	res.MinApprovals = 0
+	res.NeedsApproval = false
+	res.IsSafe = true
+	if res.MatchedPattern == "" {
+		res.MatchedPattern = defaultAllowPattern
+	}
 }
 
 // applyParseUpgrade enforces conservative behavior when normalization fails.

--- a/internal/core/patterns_test.go
+++ b/internal/core/patterns_test.go
@@ -114,21 +114,21 @@ func TestClassifyCommand(t *testing.T) {
 		{
 			name:              "git status",
 			cmd:               "git status",
-			wantTier:          "",
+			wantTier:          RiskTier(RiskSafe),
 			wantApprovals:     0,
 			wantNeedsApproval: false,
 		},
 		{
 			name:              "ls",
 			cmd:               "ls -la",
-			wantTier:          "",
+			wantTier:          RiskTier(RiskSafe),
 			wantApprovals:     0,
 			wantNeedsApproval: false,
 		},
 		{
 			name:              "cat file",
 			cmd:               "cat README.md",
-			wantTier:          "",
+			wantTier:          RiskTier(RiskSafe),
 			wantApprovals:     0,
 			wantNeedsApproval: false,
 		},
@@ -453,6 +453,18 @@ func TestCompoundCommandMatchedSegments(t *testing.T) {
 	}
 }
 
+func TestCompoundCommandUnmatchedDefaultsToExplicitSafe(t *testing.T) {
+	engine := NewPatternEngine()
+
+	res := engine.ClassifyCommand("git status && echo ok", "")
+	if res.Tier != RiskTier(RiskSafe) || res.NeedsApproval || !res.IsSafe {
+		t.Fatalf("Tier=%q NeedsApproval=%v IsSafe=%v, want safe/false/true", res.Tier, res.NeedsApproval, res.IsSafe)
+	}
+	if res.MatchedPattern != defaultAllowPattern {
+		t.Fatalf("MatchedPattern=%q, want %q", res.MatchedPattern, defaultAllowPattern)
+	}
+}
+
 func TestUpgradeTier(t *testing.T) {
 	tests := []struct {
 		name string
@@ -656,24 +668,34 @@ func TestClassifyCommandEdgeCases(t *testing.T) {
 
 	t.Run("empty command", func(t *testing.T) {
 		result := engine.ClassifyCommand("", "")
-		// Empty command should not match any pattern
 		if result.NeedsApproval {
 			t.Errorf("empty command should not need approval")
+		}
+		if result.Tier != RiskTier(RiskSafe) || !result.IsSafe {
+			t.Errorf("empty command Tier=%q IsSafe=%v, want safe/true", result.Tier, result.IsSafe)
 		}
 	})
 
 	t.Run("whitespace only command", func(t *testing.T) {
 		result := engine.ClassifyCommand("   ", "")
-		// Whitespace should not match any pattern
 		if result.NeedsApproval && result.Tier != RiskTierCaution {
 			t.Errorf("whitespace command should not match dangerous pattern")
 		}
+		if !result.NeedsApproval && (result.Tier != RiskTier(RiskSafe) || !result.IsSafe) {
+			t.Errorf("whitespace command Tier=%q IsSafe=%v, want safe/true", result.Tier, result.IsSafe)
+		}
 	})
 
-	t.Run("unknown command falls through to no match", func(t *testing.T) {
+	t.Run("unknown command defaults to explicit safe", func(t *testing.T) {
 		result := engine.ClassifyCommand("my-custom-command --flag", "")
 		if result.NeedsApproval {
 			t.Errorf("unknown command should not need approval")
+		}
+		if result.Tier != RiskTier(RiskSafe) || !result.IsSafe {
+			t.Errorf("unknown command Tier=%q IsSafe=%v, want safe/true", result.Tier, result.IsSafe)
+		}
+		if result.MatchedPattern != defaultAllowPattern {
+			t.Errorf("unknown command MatchedPattern=%q, want %q", result.MatchedPattern, defaultAllowPattern)
 		}
 	})
 }
@@ -1050,7 +1072,7 @@ func TestExportClaudeHook_UsesSearchNotMatch(t *testing.T) {
 	// .search is the unanchored matcher; .match is anchored to
 	// position 0. The hook should use .search.
 	if strings.Contains(out, "if p.match(command):") {
-		t.Errorf("ExportClaudeHook still uses p.match(); should use p.search() (issue #4 follow-on).\n"+
+		t.Errorf("ExportClaudeHook still uses p.match(); should use p.search() (issue #4 follow-on).\n" +
 			"Anchored matching loses mid-command hits like `DROP DATABASE` inside `psql -c '...'`.")
 	}
 	if !strings.Contains(out, "if p.search(command):") {

--- a/internal/e2e/risk_tier_classification_test.go
+++ b/internal/e2e/risk_tier_classification_test.go
@@ -54,13 +54,12 @@ func TestRiskTierClassification_CommandMatrix(t *testing.T) {
 		{"kubectl delete pod", "kubectl delete pod nginx-123", db.RiskTier(core.RiskSafe), 0, false},
 		{"npm cache clean", "npm cache clean", db.RiskTier(core.RiskSafe), 0, false},
 
-		// NO MATCH tier (unknown commands) - allowed without review for usability
-		// Note: tier is empty string "", NeedsApproval=false
-		{"ls", "ls -la", "", 0, false},
-		{"cat file", "cat /etc/passwd", "", 0, false},
-		{"echo", "echo hello world", "", 0, false},
-		{"pwd", "pwd", "", 0, false},
-		{"git status", "git status", "", 0, false},
+		// Unmatched allowed commands are explicit SAFE, never null tier.
+		{"ls", "ls -la", db.RiskTier(core.RiskSafe), 0, false},
+		{"cat file", "cat /etc/passwd", db.RiskTier(core.RiskSafe), 0, false},
+		{"echo", "echo hello world", db.RiskTier(core.RiskSafe), 0, false},
+		{"pwd", "pwd", db.RiskTier(core.RiskSafe), 0, false},
+		{"git status", "git status", db.RiskTier(core.RiskSafe), 0, false},
 	}
 
 	passed := 0


### PR DESCRIPTION
## Summary
- emit typed JSON for missing --session-id in run/request
- avoid execute help shorthand collision and typed skipped execute behavior from branch history
- load custom patterns on approval paths
- classify unmatched non-parse-error commands as explicit safe with matched_pattern=unmatched_default_allow instead of tier=null

## SkillOS evidence
- Bead: skillos-slb-run-request-silent-daemon-down-4iz6t
- Active HOME binary deployed through SLB two-person gate, final /Users/josh/.local/bin/slb-bin sha256=603c8312e44868aaf6808c13d7e6e6d2b14752ff05dc998791d33d4b80e686c7
- Active version: v0.3.1-12-gfd601e4
- Active probes: slb patterns test true --json and slb check true --json both return tier=safe, is_safe=true, matched_pattern=unmatched_default_allow, min_approvals=0
- Missing-session probes return parseable JSON status=missing_session_id for run/request
- slb execute --help exits 0

## Tests
- go test ./internal/core ./internal/cli ./internal/e2e
- go test ./internal/cli ./internal/core ./internal/config ./internal/db
- go test ./internal/daemon -run TestLoadDaemonCustomPatterns

Full go test ./... still had unrelated pre-existing daemon temp-path and git pre-commit-hook expectation failures noted in the bead comments.